### PR TITLE
fix(content-loader): set baseUrl before setFillStyle, setClipStyle

### DIFF
--- a/projects/ngneat/content-loader/src/lib/content-loader.component.ts
+++ b/projects/ngneat/content-loader/src/lib/content-loader.component.ts
@@ -53,12 +53,13 @@ export class ContentLoaderComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.animationValues = this.rtl ? this.rtlAnimation : this.defautlAnimation;
-    this.setFillStyle();
-    this.setClipStyle();
 
     if (this.baseUrl === '' && isPlatformBrowser(this.platformId)) {
       this.baseUrl = window.location.pathname;
     }
+
+    this.setFillStyle();
+    this.setClipStyle();
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngneat/content-loader/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
Hotfix

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```
Define 
    if (this.baseUrl === '' && isPlatformBrowser(this.platformId)) {
      this.baseUrl = window.location.pathname;
    }
after setFillStyle(), setClipStyle() function call.
With this statement, this.fillStyle not include baseUrl.
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sorry for my mistake. I was mistake when resolving conflicts https://github.com/ngneat/content-loader/pull/42 

Issue Number: N/A

## What is the new behavior?

this condition should be defined before setFillStyle, setClipStyle function call

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
