### PR TITLE
Old Browsr (IE) support

### DIFF
--- a/projects/ngneat/content-loader/src/lib/content-loader.component.ts
+++ b/projects/ngneat/content-loader/src/lib/content-loader.component.ts
@@ -7,6 +7,8 @@ function uid() {
     .substring(2);
 }
 
+const isIE = navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > -1;
+
 @Component({
   selector: 'content-loader',
   templateUrl: './content-loader.component.html'
@@ -54,6 +56,7 @@ export class ContentLoaderComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.animationValues = this.rtl ? this.rtlAnimation : this.defautlAnimation;
+    this.animate = isIE ? false : this.animate;
 
     if (this.baseUrl === '' && !this.ignoreBaseUrl && isPlatformBrowser(this.platformId)) {
       this.baseUrl = window.location.pathname;

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -52,11 +52,14 @@
  *
  */
 
+import 'core-js/es6/array';
+import 'core-js/es6/symbol';
+import 'core-js/es6/promise';
+
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
-
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   }


### PR DESCRIPTION
## PR Checklist

**IE does not support <animate> SVG element.

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animate**

What kind of change does this PR introduce?

[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

 <animate> is in the DOM IE

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

animate = false if is IE
and some polyfills was added

