### PR TITLE
fix(lib): default size for content loader viewbox

### DIFF
--- a/projects/ngneat/content-loader/src/lib/content-loader.component.ts
+++ b/projects/ngneat/content-loader/src/lib/content-loader.component.ts
@@ -29,7 +29,7 @@ export class ContentLoaderComponent {
 
   @Input() speed = 1.2;
 
-  @Input() viewBox: string = '0 0 0 0';
+  @Input() viewBox: string = '0 0 400 130';
 
   @Input() gradientRatio = 2;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/content-loader/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/content-loader/issues/72

## What is the new behavior?

Adding default value for "viewBox" input (previous default value of width and height)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
